### PR TITLE
Switch await-zeebe to use rollout status (fixes #34)

### DIFF
--- a/include/camunda.mk
+++ b/include/camunda.mk
@@ -67,7 +67,7 @@ watch-zeebe:
 
 .PHONY: await-zeebe
 await-zeebe:
-	kubectl wait --for=condition=Ready pod -n $(namespace) -l app.kubernetes.io/name=zeebe --timeout=900s
+	kubectl rollout status --watch statefulset/$(release)-zeebe --timeout=900s -n $(namespace)
 
 .PHONY: port-zeebe
 port-zeebe:


### PR DESCRIPTION
see: https://stackoverflow.com/a/69820276/3165190