### PR TITLE
Define mandatory Health Probe for Azure Load Balancer

### DIFF
--- a/azure/ingress/nginx/tls/Makefile
+++ b/azure/ingress/nginx/tls/Makefile
@@ -53,6 +53,7 @@ nginx-dns-tls:
 	helm search repo ingress-nginx
 	helm install ingress-nginx ingress-nginx/ingress-nginx --namespace ingress-nginx --create-namespace --wait \
 	--set controller.service.annotations."service\.beta\.kubernetes\.io/azure-dns-label-name"=$(dnsLabel) \
+	--set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-health-probe-request-path"="/healthz" \
 	--set controller.service.annotations."nginx\.ingress.kubernetes.io/ssl-redirect"="true" \
 	--set controller.service.annotations."cert-manager.io/cluster-issuer"="letsencrypt"
 


### PR DESCRIPTION
The ingress annotation `"service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path": "/healthz"` is mandatory for the service. Otherwise, the native Azure load balancer created by this service, will **not forward any public traffic to the ingress controller**.

See also: https://learn.microsoft.com/en-us/azure/aks/ingress-basic?tabs=azure-cli#basic-configuration