### PR TITLE
aws: automatically create ebs-csi-controller add-on if clusterVersion >= 1.23 // add metrics

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -65,8 +65,9 @@ The first IP Address is used to configure Camunda Ingress Rules.
 
 ## EBS CSI Driver Addon
 
-AWS requires you to install the [EBS CSI Driver Addon](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) on EKS Clusters running version 1.23. 
+AWS requires you to install the [EBS CSI Driver Addon](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) on EKS Clusters running version >= 1.23. 
 
-Any persistent volumes will fail on EKS Clusters v1.23 unless the EBS CSI Driver Addon is installed. 
+Any persistent volumes will fail on EKS Clusters >= v1.23 unless the EBS CSI Driver Addon is installed. 
+The addon will be installed automatically if the version is less or equal to 1.23. Be aware that during the installation two files are written which have to be saved (SHIFT-Z-Z). Before saving the second file please wait 30 seconds to give AWS enough time to create the requested role before continue.
 
-This project has some scripts to help install and configure the addon. Take a look at the `make` target named `ebs-csi-controller-addon` inside [kubernetes-aws.mk](include/kubernetes-aws.mk) to see how the scripts work. 
+This project has some scripts to help install and configure the addon. Take a look at the `make` target named `install-ebs-csi-controller-addon` inside [kubernetes-aws.mk](include/kubernetes-aws.mk) to see how the scripts work. 

--- a/aws/ingress/nginx/tls/Makefile
+++ b/aws/ingress/nginx/tls/Makefile
@@ -50,11 +50,9 @@ chartValues ?= camunda-values-ingress-tls-aws.yaml
 .PHONY: all
 all: ingress-nginx cert-manager letsencrypt-prod camunda-values-nginx-tls-aws.yaml camunda annotate-ingress-tls external-urls
 
-# 0 kube from aks.mk: Create Kubernetes cluster. (No aplication gateway required)
-# BEWARE!!! Need to carefully run this manually: `make ebs-csi-controller-addon`
-# and remember to run `make metrics` after
+# 0 kube from aks.mk: Create Kubernetes cluster.
 .PHONY: kube
-kube: kube-aws oidc-provider
+kube: kube-aws install-ebs-csi-controller-addon oidc-provider metrics
 
 # 1 cert-manager from cert-manager.mk: create certificate manager for tls
 


### PR DESCRIPTION
now the ebs-csi-controller-addon will be automatically installed if the clusterVersion is >= 1.23. It will also wait for completion of add-on installation.
metrics are also added to goal kube.