### PR TITLE
fixed wrong secret name

### DIFF
--- a/ingress-nginx/camunda-values.yaml
+++ b/ingress-nginx/camunda-values.yaml
@@ -54,7 +54,7 @@ webModeler:
   contextPath: "/modeler"
   image:
     pullSecrets:
-      - name: camunda-docker-registry
+      - name: camunda-docker-registry-secret
   restapi:
     mail:
       fromAddress: YOUR_EMAIL


### PR DESCRIPTION
web-modeler components could not be installed as the secret was named wrongly